### PR TITLE
Updated esmvaltool

### DIFF
--- a/roles/esmvaltool/defaults/main.yml
+++ b/roles/esmvaltool/defaults/main.yml
@@ -3,7 +3,7 @@
 # Location of esmvaltool repo
 esmvaltool_app: /mnt/apps/ESMValTool
 # Version of esmvaltool
-esmvaltool_version: 0084e806287417604ef84bfa5ab86063d5d6da26
+esmvaltool_version: b383f9400cdc1ca69eff08329afeb8c0ae9fe10f
 # Location of input data
 esmvaltool_rootpath: /mnt/data/esmvaltool
 # Location where conda is installed

--- a/roles/esmvaltool/tasks/main.yml
+++ b/roles/esmvaltool/tasks/main.yml
@@ -4,15 +4,18 @@
     repo: https://github.com/ESMValGroup/ESMValTool.git
     dest: '{{ esmvaltool_app }}'
     version: '{{ esmvaltool_version }}'
+  register: esmvaltool_repo_result
 - name: esmvaltool conda deps
   command: conda env update --file environment.yml -q --name base
   args:
     creates: '{{ conda_root }}/lib/python3.7/site-packages/esmvalcore'
+  when: esmvaltool_repo_result.changed
 - name: esmvaltool
   command: '{{ conda_root }}/bin/pip install .'
   args:
     chdir: '{{ esmvaltool_app }}'
     creates: '{{ conda_root }}/lib/python3.7/site-packages/esmvaltool'
+  when: esmvaltool_repo_result.changed
 - name: esmvaltool in path
   file:
     src: '{{ conda_root }}/bin/esmvaltool'


### PR DESCRIPTION
Ansible code does not trigger conda and pip install.

Still needs work so when a new version of ESMValTool (esmvaltool_version in /home/stefanv/git/ewc/infra/roles/esmvaltool/defaults/main.yml) is set then the `conda update` and `pip install` also get triggered. For now ran them manually.