### PR TITLE
Drop go dir directly after notification was send out

### DIFF
--- a/roles/conda/defaults/main.yml
+++ b/roles/conda/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # Checksum of conda tarball, prevents re-download
-conda_tarball_checksum: sha256:879457af6a0bf5b34b48c12de31d4df0ee2f06a8e68768e5758c3293b2daf688.
+conda_tarball_checksum: sha256:1314b90489f154602fd794accfc90446111514a5a72fe1f71ab83e07de9504a7
 # Location where conda tarball is downloaded to
 conda_tarball_root: /mnt/apps
 # Location where conda will be installed

--- a/roles/hymuse/tasks/main.yml
+++ b/roles/hymuse/tasks/main.yml
@@ -8,6 +8,8 @@
     force: yes
   notify:
    - Clean amuse-framework
+- name: Flush handlers
+  meta: flush_handlers
 - name: amuse-framework - apt deps
   apt:
     update_cache: yes
@@ -55,6 +57,8 @@
   notify:
    - Clean HyMUSE build
    - Clean HyMUSE install
+- name: Flush handlers
+  meta: flush_handlers
 - name: hymuse - build
   command: '{{ conda_environment_bin }}/python3 setup.py build'
   args:

--- a/roles/singularity/tasks/go.yml
+++ b/roles/singularity/tasks/go.yml
@@ -6,6 +6,8 @@
     checksum: sha256:{{ go_sha256sum }}
   notify:
    - Drop go dir
+- name: Flush handlers
+  meta: flush_handlers
 - name: Unarchive Go binary tarball
   unarchive:
     src: /mnt/apps/go{{ go_version }}.linux-amd64.tar.gz

--- a/roles/terria/tasks/main.yml
+++ b/roles/terria/tasks/main.yml
@@ -19,6 +19,8 @@
   notify:
     - Restart terriamap
     - Clean terriamap build
+- name: Flush handlers
+  meta: flush_handlers
 - name: Yarn
   npm:
     name: yarn
@@ -36,6 +38,8 @@
   notify:
     - Restart terriamap
     - Clean terriajs build
+- name: Flush handlers
+  meta: flush_handlers
 - name: Install TerriaMap dependencies
   yarn:
     path: /mnt/apps/TerriaMap


### PR DESCRIPTION
Fixes #70

Due to changes in #69 the notification handlers where executed at the wrong place.

Was able to successfully run local Vagrant provisioning until `TASK [ewatercycle : Install eWaterCycle conda environment]` which will be fixed PR #75