### PR TITLE
Prevent warning during listflood pararmeter set load

### DIFF
--- a/roles/ewatercycle/templates/ewatercycle.yaml.j2
+++ b/roles/ewatercycle/templates/ewatercycle.yaml.j2
@@ -81,7 +81,7 @@ parameter_sets:
     directory: lisflood_global-masked_01degree
     config: lisflood_global-masked_01degree/settings_lisflood_ERA5.xml
     target_model: lisflood
-    supported_model_versions: !!set {2020.10: null}
+    supported_model_versions: !!set {20.10: null}
 
   # Tech paper
   pcrglobwb_merrimack_05min:

--- a/roles/ewatercycle/templates/ewatercycle.yaml.j2
+++ b/roles/ewatercycle/templates/ewatercycle.yaml.j2
@@ -81,6 +81,7 @@ parameter_sets:
     directory: lisflood_global-masked_01degree
     config: lisflood_global-masked_01degree/settings_lisflood_ERA5.xml
     target_model: lisflood
+    supported_model_versions: !!set {2020.10: null}
 
   # Tech paper
   pcrglobwb_merrimack_05min:


### PR DESCRIPTION
By adding `supported_model_versions` field to config.