### PR TITLE
Install pyOpenSSL==22.1.0

### DIFF
--- a/roles/launcher/tasks/main.yml
+++ b/roles/launcher/tasks/main.yml
@@ -19,7 +19,7 @@
   # Fixes X509_V_FLAG_CB_ISSUER_CHECK error
   ansible.builtin.pip:
     executable: /usr/local/bin/pip3
-    name: pyOpenSSL==22.1.0
+    name: pyOpenSSL>=22.1.0
 - name: Experiment launcher systemd file
   template:
     src: experiment-launcher.systemd.j2

--- a/roles/launcher/tasks/main.yml
+++ b/roles/launcher/tasks/main.yml
@@ -15,6 +15,11 @@
     name: /mnt/apps/launcher
   notify:
     - restart experiment-launcher
+- name: Install compatible pyopenssl
+  # Fixes X509_V_FLAG_CB_ISSUER_CHECK error
+  ansible.builtin.pip:
+    executable: /usr/local/bin/pip3
+    name: pyOpenSSL==22.1.0
 - name: Experiment launcher systemd file
   template:
     src: experiment-launcher.systemd.j2


### PR DESCRIPTION
Between boot and roles/terria/tasks/main.yml an incompatible version of pyopenssl is installed.

The launcher is the only place where pip is run so a compatible pyopenssl is installed there.

Fixes #133