### PR TITLE
Pin python==3.10, esmpy<8.4 in env.yml

### DIFF
--- a/roles/ewatercycle/files/environment.yml
+++ b/roles/ewatercycle/files/environment.yml
@@ -5,12 +5,12 @@ channels:
   - defaults
 dependencies:
   # TODO pin versions for reproducibility. Use `conda env export` and `pip list` to get versions
-  - python>=3.7
+  - python==3.10
   - subversion # for ewatercycle.parameter_sets
   - esmvaltool-python>=2.3.0
   # Pin esmpy so we dont get forced to run all parallel tasks on single cpu
   # Can be removed once https://github.com/ESMValGroup/ESMValCore/issues/1208 is resolved.
-  - esmpy!=8.1.0
+  - esmpy!=8.1.0,<8.4
   # Line above are copy from https://github.com/eWaterCycle/ewatercycle/blob/main/environment.yml
   - ansible
   - pip:


### PR DESCRIPTION
Tested with 
```bash
micromamba env create -n infra_test --file roles/ewatercycle/files/environment.yml
micromamba activate infra_test
python
```

```py
import ESMF as esmpy
import ewatercycle
```

Build successful, imports resolve fine.