### PR TITLE
Add humber parameter sets and shapefile

### DIFF
--- a/roles/ewatercycle/templates/ewatercycle.yaml.j2
+++ b/roles/ewatercycle/templates/ewatercycle.yaml.j2
@@ -100,6 +100,17 @@ parameter_sets:
     config: wflow_sbm_era5_test.ini
     target_model: wflow
     supported_model_versions: !!set {2020.1.1: null, 2020.1.2: null, 2020.1.3: null}
+
+  # For Digital bastards workshop
+  wflow_humber:
+    directory: wflow_humber
+    config: wflow_sbm.toml
+    target_model: wflowjl
+  sfincs_humber:
+    directory: sfincs_humber
+    config: sfincs.inp
+    target_model: sfincs
+
 parameterset_dir: {{ parameterset_dir }}
 {# ewatercycle<1.4.1 will use singularity instead of apptainer #}
 {% set pyewatercycle_pre_apptainer_versions = ('1.4.1', '1.4.0', '1.3.0', '1.2.0', '1.1.4', '1.1.3', '1.1.2', '1.1.1', '1.1.0', '1.0.0')  %}

--- a/roles/prep_shared_data/defaults/main.yml
+++ b/roles/prep_shared_data/defaults/main.yml
@@ -52,7 +52,7 @@ climate_data_root_dir: '{{ data_root }}/climate-data'
 # Location where esmvaltool aux data should be placed
 auxiliary_data_dir: '{{ climate_data_root_dir }}/aux'
 # Version of https://github.com/eWaterCycle/recipes_auxiliary_datasets to checkout to {{ auxiliary_data_dir }}
-esmvaltool_aux_version: dde5fcc78398ff3208589150b52bf9dd0b3bfb30
+esmvaltool_aux_version: 279e39b3815d9779e13d93376b42732495ef6330
 # Location where eWatercycle example parameter sets will be downloaded to
 parameter_set_root_dir: '{{ data_root }}/parameter-sets'
 # Location where eWatercycle example forcings will be downloaded to


### PR DESCRIPTION
The humber parameter sets have been uploaded to dcache with 

```shell
rclone copy sfincs_humber dcache:parameter-sets/sfincs_humber
rclone copy wflow_humber dcache:parameter-sets/wflow_humber
```

And the shape file was added to https://github.com/eWaterCycle/recipes_auxiliary_datasets

